### PR TITLE
feat: add cover image integration for project cards

### DIFF
--- a/src/lib/notion.ts
+++ b/src/lib/notion.ts
@@ -35,6 +35,7 @@ export interface NotionProject {
   createdTime: string;
   lastEditedTime: string;
   slug: string;
+  coverImage?: string;
   tasks?: any[];
 }
 
@@ -142,6 +143,11 @@ export async function getNotionProjects(): Promise<NotionProject[]> {
       projectPages.map(async (page: any) => {
         const properties: NotionPageProperties = page.properties;
 
+        // Extract cover image URL from page.cover
+        const coverImage = page.cover?.external?.url || 
+                          page.cover?.file?.url || 
+                          undefined;
+
         return {
           id: page.id,
           title: properties.Title?.title?.[0]?.plain_text || 'Untitled',
@@ -164,6 +170,7 @@ export async function getNotionProjects(): Promise<NotionProject[]> {
           lastEditedTime: 'last_edited_time' in page ? page.last_edited_time : new Date().toISOString(),
           slug: properties.Slug?.rich_text?.[0]?.plain_text || 
                 properties.Title?.title?.[0]?.plain_text?.toLowerCase().replace(/\s+/g, '-') || 'untitled',
+          coverImage,
         };
       })
     );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -78,13 +78,27 @@ export default function Home({ projects = [], publications = [], githubUser = nu
                   projects.map((project) => (
                     <Link key={project.id} href={`/projects/${project.slug}`}>
                       <div className="border rounded-2 p-3 color-bg-default cursor-pointer hover:color-bg-subtle transition-colors">
-                        <div 
-                          className="w-full color-bg-inset color-border-muted" 
-                          style={{ 
-                            aspectRatio: '16/9',
-                            border: '1px solid'
-                          }} 
-                        />
+                        {project.coverImage ? (
+                          <div 
+                            className="w-full" 
+                            style={{ 
+                              aspectRatio: '16/9',
+                              backgroundImage: `url(${project.coverImage})`,
+                              backgroundSize: 'cover',
+                              backgroundPosition: 'center',
+                              borderRadius: '6px'
+                            }} 
+                          />
+                        ) : (
+                          <div 
+                            className="w-full color-bg-inset color-border-muted" 
+                            style={{ 
+                              aspectRatio: '16/9',
+                              border: '1px solid',
+                              borderRadius: '6px'
+                            }} 
+                          />
+                        )}
                         <div className="mt-2">
                           <Text className="text-large text-semibold color-fg-default">{project.title}</Text>
                           <div>
@@ -121,7 +135,8 @@ export default function Home({ projects = [], publications = [], githubUser = nu
                           className="w-full color-bg-inset color-border-muted" 
                           style={{ 
                             aspectRatio: '16/9',
-                            border: '1px solid'
+                            border: '1px solid',
+                            borderRadius: '6px'
                           }} 
                         />
                         <div className="mt-2">
@@ -205,7 +220,8 @@ export const getStaticProps: GetStaticProps = async () => {
         privacyLevel: 'Public',
         createdTime: new Date().toISOString(),
         lastEditedTime: new Date().toISOString(),
-        slug: 'portfolio-site'
+        slug: 'portfolio-site',
+        coverImage: undefined
       }
     ]
     


### PR DESCRIPTION
Closes #2

## Summary
- Add coverImage field to NotionProject interface
- Fetch cover images from Notion API (page.cover)
- Update project cards to display cover images with fallback
- Handle different cover types (external URLs, Notion files)

## Test Plan
- [ ] Verify project cards display cover images from Notion
- [ ] Test fallback behavior for projects without covers
- [ ] Check responsive layout on different screen sizes

Generated with [Claude Code](https://claude.ai/code)