### PR TITLE
Draft homepage and selected work copy

### DIFF
--- a/docs/homepage-selected-work-copy.md
+++ b/docs/homepage-selected-work-copy.md
@@ -10,6 +10,9 @@ Status: draft for issue #11. This document covers copy only, not UI.
 4. Short bio
 5. Contact or call to action
 
+The sections below are intentionally organized in the same order as the
+homepage flow, with editorial notes kept close to the copy they affect.
+
 ## Positioning Goal
 
 Present Samuel Alake as a product designer and design engineer for AI-native
@@ -33,33 +36,6 @@ usable software.
 ### Alternate Short Headline
 
 Design + engineering for AI-native products.
-
-## Short Bio
-
-Samuel Alake is a product designer evolving into an AI-native product builder.
-He combines large-scale product judgment from Meta with hands-on design
-engineering through Rem and focused mobile prototyping through Wayfind. He works
-best with teams building new product surfaces, complex interaction models, or
-early-stage products that need someone who can move between design, code, and
-product strategy.
-
-## Capability Framing
-
-### Capability Strip
-
-- AI-native product design
-- Design engineering
-- UX engineering
-- AI prototyping
-- Interaction systems
-- Mobile product architecture
-
-### Supporting Capability Copy
-
-I work best where product direction, interface craft, and implementation need
-to stay tightly connected. That includes shaping AI-native workflows, designing
-trust-sensitive interactions, prototyping product behavior in code, and helping
-teams turn ambiguous ideas into durable product decisions.
 
 ## Selected Work Intro
 
@@ -124,13 +100,53 @@ Mobile EV navigation prototype
 #### Card Description
 
 Prototyped a SwiftUI, MapKit, and Firebase EV navigation experience focused on
-charging-aware routing, map-first search, route confidence, and serious mobile
-product architecture.
+charging-aware routing, map-first search, route confidence, and real mobile app
+architecture.
 
 #### Role-Fit Signal
 
 Shows mobile product judgment, prototyping depth, and the ability to make an
 early product feel concrete and testable.
+
+## Capability Framing
+
+### Capability Strip
+
+- AI-native product design
+- Design engineering
+- UX engineering
+- AI prototyping
+- Interaction systems
+- Mobile product architecture
+
+### Supporting Capability Copy
+
+I work best where product direction, interface craft, and implementation need
+to stay tightly connected. That includes shaping AI-native workflows, designing
+trust-sensitive interactions, prototyping product behavior in code, and helping
+teams turn ambiguous ideas into durable product decisions.
+
+## Short Bio
+
+Samuel Alake is a product designer and AI-native product builder. He combines
+large-scale product judgment from Meta with hands-on design engineering through
+Rem and focused mobile prototyping through Wayfind. He works best with teams
+building new product surfaces, complex interaction models, or early-stage
+products that need someone who can move between design, code, and product
+strategy.
+
+## Contact Or Call To Action
+
+### CTA Copy
+
+For AI-native product, design engineering, UX engineering, or founding-designer
+work, reach out to Samuel.
+
+## Voice Notes
+
+- Use first person for homepage hero and CTA copy so the site speaks directly.
+- Use third person for short bio copy so it can also support about-page,
+  recruiting, and profile contexts.
 
 ## Tone Guardrails
 

--- a/docs/homepage-selected-work-copy.md
+++ b/docs/homepage-selected-work-copy.md
@@ -2,10 +2,18 @@
 
 Status: draft for issue #11. This document covers copy only, not UI.
 
+## Suggested Homepage Section Order
+
+1. Hero
+2. Selected work
+3. Capability strip
+4. Short bio
+5. Contact or call to action
+
 ## Positioning Goal
 
 Present Samuel Alake as a product designer and design engineer for AI-native
-tools, complex workflows, and working prototypes. The copy should read
+tools, complex workflows, and product prototypes. The copy should read
 credible, specific, and jobs-first without drifting into petition language.
 
 ## Homepage Hero
@@ -24,16 +32,16 @@ usable software.
 
 ### Alternate Short Headline
 
-Product designer and design engineer for AI-native tools and complex workflows.
+Design + engineering for AI-native products.
 
 ## Short Bio
 
 Samuel Alake is a product designer evolving into an AI-native product builder.
 He combines large-scale product judgment from Meta with hands-on design
-engineering through Rem and focused mobile prototyping through Wayfind. He is
-best suited to teams building new product surfaces, complex interaction models,
-or early-stage products that need someone who can move between design, code,
-and product strategy.
+engineering through Rem and focused mobile prototyping through Wayfind. He works
+best with teams building new product surfaces, complex interaction models, or
+early-stage products that need someone who can move between design, code, and
+product strategy.
 
 ## Capability Framing
 
@@ -73,8 +81,9 @@ Product systems at scale
 #### Card Description
 
 Designed interaction systems and growth-facing product experiences inside
-Meta-scale complexity, with work spanning notifications, social experiences,
-prototyping culture, and cross-functional product judgment.
+Meta-scale complexity, including notifications, social celebration surfaces,
+video/web growth explorations, prototyping culture, and cross-functional product
+judgment.
 
 #### Role-Fit Signal
 
@@ -132,12 +141,3 @@ early product feel concrete and testable.
   "creating meaningful experiences."
 - Keep Meta, Rem, and Wayfind framed as distinct proof types: scale, working AI
   system, and serious prototype.
-
-## Suggested Homepage Section Order
-
-1. Hero
-2. Selected work
-3. Capability strip
-4. Short bio
-5. Contact or call to action
-

--- a/docs/homepage-selected-work-copy.md
+++ b/docs/homepage-selected-work-copy.md
@@ -1,0 +1,143 @@
+# Homepage And Selected Work Copy
+
+Status: draft for issue #11. This document covers copy only, not UI.
+
+## Positioning Goal
+
+Present Samuel Alake as a product designer and design engineer for AI-native
+tools, complex workflows, and working prototypes. The copy should read
+credible, specific, and jobs-first without drifting into petition language.
+
+## Homepage Hero
+
+### Primary Headline
+
+Samuel Alake designs and builds AI-native products, interaction systems, and
+working prototypes.
+
+### Supporting Copy
+
+I am a product designer and design engineer working across product thinking,
+interaction design, and implementation. My work spans Meta-scale product
+systems, AI assistant workflows, and mobile prototypes that turn ideas into
+usable software.
+
+### Alternate Short Headline
+
+Product designer and design engineer for AI-native tools and complex workflows.
+
+## Short Bio
+
+Samuel Alake is a product designer evolving into an AI-native product builder.
+He combines large-scale product judgment from Meta with hands-on design
+engineering through Rem and focused mobile prototyping through Wayfind. He is
+best suited to teams building new product surfaces, complex interaction models,
+or early-stage products that need someone who can move between design, code,
+and product strategy.
+
+## Capability Framing
+
+### Capability Strip
+
+- AI-native product design
+- Design engineering
+- UX engineering
+- AI prototyping
+- Interaction systems
+- Mobile product architecture
+
+### Supporting Capability Copy
+
+I work best where product direction, interface craft, and implementation need
+to stay tightly connected. That includes shaping AI-native workflows, designing
+trust-sensitive interactions, prototyping product behavior in code, and helping
+teams turn ambiguous ideas into durable product decisions.
+
+## Selected Work Intro
+
+Selected work across large-scale product systems, AI design engineering, and
+mobile product prototyping.
+
+## Project Card Copy
+
+### Meta
+
+#### Card Title
+
+Meta
+
+#### Card Label
+
+Product systems at scale
+
+#### Card Description
+
+Designed interaction systems and growth-facing product experiences inside
+Meta-scale complexity, with work spanning notifications, social experiences,
+prototyping culture, and cross-functional product judgment.
+
+#### Role-Fit Signal
+
+Shows product judgment, systems thinking, and comfort operating inside large,
+complex organizations.
+
+### Rem
+
+#### Card Title
+
+Rem
+
+#### Card Label
+
+AI design engineering
+
+#### Card Description
+
+Built and shaped an AI assistant product across iOS, macOS, backend, gateway,
+settings, permissions, and trust boundaries, moving between UX architecture,
+interaction design, and implementation.
+
+#### Role-Fit Signal
+
+Shows end-to-end AI-native product thinking and the ability to turn product
+ideas into working systems.
+
+### Wayfind
+
+#### Card Title
+
+Wayfind
+
+#### Card Label
+
+Mobile EV navigation prototype
+
+#### Card Description
+
+Prototyped a SwiftUI, MapKit, and Firebase EV navigation experience focused on
+charging-aware routing, map-first search, route confidence, and serious mobile
+product architecture.
+
+#### Role-Fit Signal
+
+Shows mobile product judgment, prototyping depth, and the ability to make an
+early product feel concrete and testable.
+
+## Tone Guardrails
+
+- Prefer direct, specific language over inflated claims.
+- Keep school, founder, and NIW-adjacent credibility implicit rather than
+  foregrounded.
+- Avoid generic portfolio phrases such as "passionate designer" or
+  "creating meaningful experiences."
+- Keep Meta, Rem, and Wayfind framed as distinct proof types: scale, working AI
+  system, and serious prototype.
+
+## Suggested Homepage Section Order
+
+1. Hero
+2. Selected work
+3. Capability strip
+4. Short bio
+5. Contact or call to action
+


### PR DESCRIPTION
## Summary
- add a docs-only homepage and selected-work copy draft for issue #11
- cover hero copy, short bio, capability framing, and project-card copy for Meta, Rem, and Wayfind
- keep the artifact aligned to the approved blueprint direction and explicitly out of UI scope

## Testing
- `git diff --check`

## Visual QA
- Not required; this issue is copy drafting only and does not change UI

Closes #11