### PR TITLE
Add portfolio blueprint source of truth

### DIFF
--- a/docs/portfolio-blueprint.md
+++ b/docs/portfolio-blueprint.md
@@ -1,6 +1,7 @@
 # Portfolio Blueprint v1
 
-Status: approved strategic source of truth for the jobs-first portfolio pass.
+Status: approved.
+Version: v1.
 
 This blueprint is the strategic source of truth for the first jobs-focused pass
 of Samuel Alake's GitHub-backed portfolio. It should guide copy, case-study
@@ -21,10 +22,10 @@ Secondary audiences:
 
 - school/program reviewers;
 - founder/VC/accelerator readers;
-- NIW-adjacent credibility reviewers.
+- long-term credibility reviewers.
 
-Secondary outcomes matter, but the site must not read like an immigration
-petition, grant application, or exhaustive archive.
+Secondary outcomes matter, but the site must not read like a grant application
+or exhaustive credentials archive.
 
 ## Positioning
 
@@ -62,7 +63,7 @@ market signal is the combination of:
 
 The site should make that arc legible without over-explaining it:
 
-```text
+```plaintext
 Meta: product systems at scale
   -> Rem: working AI-native design engineering
   -> Wayfind: focused mobile product prototyping
@@ -231,7 +232,7 @@ Evaluation standard:
   Meta = scale and product systems; Rem = AI design engineering; Wayfind =
   serious mobile prototype/design-to-code execution.
 
-Reference standards used for this rubric:
+Supplementary point-in-time references used for this rubric:
 
 - [Google UX Design Portfolio Tips](https://services.google.com/fh/files/misc/ux_design_portfolio_tips_19.pdf)
   emphasizes clarifying role and impact in case studies.
@@ -381,7 +382,7 @@ portfolio direction explicitly needs them.
 
 ## Immediate Next Steps
 
-1. Samuel/Descartes reviews and approves or edits this blueprint.
+1. Samuel reviews and approves or edits this blueprint.
 2. Activate #11 as the first copy task.
 3. Activate case-study skeleton issues after copy direction is clear.
 4. Build the evidence target list before any screenshot capture.

--- a/docs/portfolio-blueprint.md
+++ b/docs/portfolio-blueprint.md
@@ -1,0 +1,398 @@
+# Portfolio Blueprint v1
+
+Status: approved strategic source of truth for the jobs-first portfolio pass.
+
+This blueprint is the strategic source of truth for the first jobs-focused pass
+of Samuel Alake's GitHub-backed portfolio. It should guide copy, case-study
+structure, evidence gathering, and downstream GitHub issues before any visual
+site implementation begins.
+
+## Audience Priority
+
+Primary audience: hiring teams and founders evaluating Samuel for:
+
+- AI-native product design;
+- design engineering;
+- UX engineering;
+- AI prototyping;
+- founding designer / founder-adjacent product builder roles.
+
+Secondary audiences:
+
+- school/program reviewers;
+- founder/VC/accelerator readers;
+- NIW-adjacent credibility reviewers.
+
+Secondary outcomes matter, but the site must not read like an immigration
+petition, grant application, or exhaustive archive.
+
+## Positioning
+
+Recommended positioning statement:
+
+> Samuel Alake is a product designer and design engineer building AI-native
+> product systems across consumer-scale interaction design, working AI products,
+> and mobile prototypes.
+
+Shorter homepage variant:
+
+> Product designer and design engineer for AI-native tools, complex workflows,
+> and prototypes that move between design, code, and product strategy.
+
+What the portfolio must prove quickly:
+
+1. Samuel has operated inside Meta-scale product complexity.
+2. Samuel can translate AI-native product ideas into working systems, not only
+   concepts.
+3. Samuel can move fluently between Figma, GitHub, and product knowledge systems
+   while keeping user judgment intact.
+4. Samuel's founder/operator direction is credible because it is grounded in
+   shipped and built artifacts, not only ambition.
+
+## Narrative Spine
+
+The core story:
+
+Samuel is a product designer and AI-native product builder. His strongest
+market signal is the combination of:
+
+- large-scale product judgment from Meta;
+- design-engineering execution through Rem;
+- mobile prototyping and product architecture through Wayfind.
+
+The site should make that arc legible without over-explaining it:
+
+```text
+Meta: product systems at scale
+  -> Rem: working AI-native design engineering
+  -> Wayfind: focused mobile product prototyping
+```
+
+## Site Model
+
+The first version should be compact and proof-oriented.
+
+- `/` - positioning, selected work, proof signals, concise bio, contact.
+- `/projects` - selected work index centered on Meta, Rem, Wayfind.
+- `/projects/meta` - confidential-safe large-scale product systems case study.
+- `/projects/rem` - flagship AI design-engineering case study.
+- `/projects/wayfind` - serious EV navigation prototype case study.
+- `/about` - short career narrative, role fit, and background.
+
+Do not prioritize activity pages, roadmap views, sprint views, or GitHub issue
+state UI until the selected-work spine is approved and implemented.
+
+## Homepage Structure
+
+Recommended homepage sections:
+
+1. Hero: direct positioning and role target signal.
+2. Selected work: Meta, Rem, Wayfind with consistent project cards.
+3. Capability strip: product design, design engineering, AI prototyping,
+   interaction systems, mobile/product architecture.
+4. Proof signals: Meta-scale product systems, working AI assistant, SwiftUI EV
+   prototype, GitHub-backed implementation evidence.
+5. Short bio: one paragraph, human, specific, not grandiose.
+6. Contact / links: GitHub, LinkedIn, email, resume.
+
+Avoid:
+
+- oversized generic portfolio hero language;
+- visa-packet language;
+- startup pitch-deck hype;
+- activity-feed UI before the work itself is persuasive.
+
+## Selected Work Model
+
+Each project card should use the same information model:
+
+- title;
+- project type/status;
+- one-line thesis;
+- two or three proof points;
+- evidence status.
+
+### Meta
+
+Type/status: professional product design at large social scale.
+
+Thesis:
+
+Large-scale consumer product systems, interaction patterns, notifications,
+growth/social surfaces, and design-engineering collaboration at Meta scale.
+
+Proof points:
+
+- product systems and interaction design for social/notification experiences;
+- collaboration across product, engineering, research, and prototyping culture;
+- scale-aware judgment under confidentiality and platform constraints.
+
+Evidence status:
+
+Screenshot-limited because the managed Meta Mac is locked by MDM. Use
+confidential-safe narrative, external portfolio material, resume evidence, and
+any recovered Drive artifacts. Do not block the portfolio on screenshot
+recovery.
+
+### Rem
+
+Type/status: working AI-native product and design-engineering flagship.
+
+Thesis:
+
+A working personal AI assistant across iOS, macOS, backend, gateway
+infrastructure, OpenClaw, connectors, settings, permissions, and AI-orchestrated
+development.
+
+Proof points:
+
+- intent-to-action loop across chat, voice, Agenda, tasks, calendar, connectors,
+  and gateway-executed work;
+- product architecture spanning iOS, macOS, backend, local/cloud gateways, and
+  OpenClaw;
+- trust boundaries through settings, permissions, gateway selection, linked
+  devices, and fail-closed orchestration.
+
+Evidence status:
+
+Built app and repo docs are product truth. Older Figma is design history. Use
+current app screenshots, architecture docs, TestFlight/Gmail evidence, and
+source/code artifacts where approved.
+
+### Wayfind
+
+Type/status: serious SwiftUI/MapKit/Firebase prototype.
+
+Thesis:
+
+An EV navigation and charging-aware route-planning prototype exploring map-first
+search, charging station details, route confidence, vehicle context, and mobile
+product architecture.
+
+Proof points:
+
+- SwiftUI/MapKit/Firebase architecture with sheet-over-map interaction model;
+- charging-aware search, filters, station details, and route planning;
+- design-to-code execution under real mobile constraints.
+
+Evidence status:
+
+Position as a serious prototype, not a mature launched automotive assistant or
+"Pelican but smaller." Use PRD, UI architecture docs, local source, Figma/EV Map
+flows, and real app screenshots where approved.
+
+## Shared Case-Study Architecture
+
+Each case study should follow this structure:
+
+1. Context: what product/system space the work sits in.
+2. Role: what Samuel owned or drove.
+3. Problem: why the work mattered for users and the product.
+4. Constraints: platform, scale, trust, technical, confidentiality, or maturity
+   constraints.
+5. Key decisions: the product/design/technical choices that show judgment.
+6. Evidence gallery: screenshots, Figma, docs, diagrams, source/code, metrics,
+   or artifacts with evidence quality labeled.
+7. Outcome/current status: honest result, maturity, or learning.
+8. Role-fit proof: what this project proves for the target jobs.
+
+This structure should be consistent, but not mechanical. Each case study should
+be allowed to emphasize the evidence it truly has.
+
+## Case Study Quality Rubric
+
+Use this rubric to evaluate whether a case study is strong enough for the
+jobs-first portfolio. A case study is not finished just because sections are
+filled in; it should help a hiring team quickly understand Samuel's judgment,
+role, and evidence.
+
+Evaluation standard:
+
+- Thesis clarity: the case has one clear sentence describing what the project
+  proves.
+- Role clarity: Samuel's ownership, influence, design work, technical
+  contribution, and collaboration boundaries are specific.
+- Product context: the user/product problem, audience, constraints, and stakes
+  are clear before process details appear.
+- Decision quality: the case emphasizes tradeoffs, choices, and judgment rather
+  than only showing steps taken.
+- Evidence strength: important claims are backed by screenshots, Figma frames,
+  prototypes, docs, diagrams, source/code, metrics, launch status, or other
+  artifacts.
+- Impact or learning: shipped work includes outcomes where available;
+  prototypes explain what was demonstrated, de-risked, or enabled next.
+- Job-description fit: the case maps to the roles Samuel is targeting without
+  sounding artificially tailored to one posting.
+- Skimmability: a recruiter or hiring manager can understand the case in two
+  minutes and go deeper in ten.
+- Precision: claims avoid overreach, confidential leakage, pitch-deck hype, and
+  immigration-petition tone.
+- Memorable takeaway: each case leaves one distinct role-fit proof:
+  Meta = scale and product systems; Rem = AI design engineering; Wayfind =
+  serious mobile prototype/design-to-code execution.
+
+Reference standards used for this rubric:
+
+- [Google UX Design Portfolio Tips](https://services.google.com/fh/files/misc/ux_design_portfolio_tips_19.pdf)
+  emphasizes clarifying role and impact in case studies.
+- [Nielsen Norman Group, User Experience Careers report](https://media.nngroup.com/media/reports/free/UserExperienceCareers_2nd_Edition.pdf?ref=uxdesignweekly)
+  discusses what hiring managers look for in UX candidates and portfolios.
+- [UX Design Institute, What Hiring Managers Look For in a UX Portfolio](https://www.uxdesigninstitute.com/blog/hiring-managers-ux-portfolio/)
+  frames portfolio clarity, homepage positioning, and case-study storytelling
+  for hiring review.
+
+## Project-Specific Case-Study Guidance
+
+### Meta Case Study
+
+Purpose:
+
+Prove product-system judgment, scale awareness, interaction design, prototyping
+culture, and cross-functional impact.
+
+Likely sections:
+
+- Context: Meta product design at large social scale.
+- Role: interaction systems, notifications, growth/social experiences, and
+  prototyping culture.
+- Workstreams: notification gestures/actions, push reachability,
+  birthday/social celebration, video/web growth, prototyping enablement.
+- Evidence: external portfolio doc, resume, current Framer summary, recovered
+  artifacts if available.
+- Risks: missing screenshots, confidentiality boundaries, overclaiming metrics.
+
+Confidential-safe rules:
+
+- Do not expose internal screenshots, unreleased strategy, private metrics, or
+  proprietary process details.
+- Prefer system-level descriptions over internal implementation specifics.
+- Use real names internally for drafting; Samuel can decide later what to
+  abstract publicly.
+
+### Rem Case Study
+
+Purpose:
+
+Prove AI design engineering through a working product/system.
+
+Likely sections:
+
+- Context: personal AI assistant for conversational day planning and execution.
+- Role: product/design engineering lead across UX architecture, AI interaction,
+  trust model, and implementation collaboration.
+- System: iOS, macOS, backend, gateways, OpenClaw, connectors, settings,
+  permissions, linked devices.
+- Key decisions: intent-to-action loop, Agenda/tasks/calendar model, gateway
+  distinction, connector/capability IA, fail-closed trust posture.
+- Evidence: product vision, security/trust model, orchestration docs,
+  TestFlight/Gmail evidence, app screenshots when approved.
+
+Guardrail:
+
+Avoid autonomous-assistant overclaiming. The strongest signal is serious
+AI-product judgment plus technical execution.
+
+### Wayfind Case Study
+
+Purpose:
+
+Prove mobile product architecture and design-to-code prototyping.
+
+Likely sections:
+
+- Context: EV navigation requires route confidence, charging awareness, vehicle
+  context, and clear map/search workflows.
+- Role: designer-builder translating product requirements into
+  SwiftUI/MapKit/Firebase prototype architecture.
+- Product spine: map, search, route planning, charging search/details,
+  vehicle/OBD exploration, backend services.
+- Evidence: PRD, current UI architecture doc, backend services implementation
+  doc, local source, Figma/EV Map screens, app screenshots when approved.
+
+Guardrail:
+
+Be honest about maturity. The value is product thinking plus design-to-code
+execution under real mobile constraints.
+
+## Evidence Strategy
+
+Evidence should be explicit and labeled. The portfolio should not imply every
+artifact has the same certainty.
+
+Evidence types:
+
+- real app screenshot;
+- Figma/design-history frame;
+- source/code artifact;
+- architecture or product doc;
+- resume or employment evidence;
+- public or external portfolio material;
+- metric or result;
+- diagram created for explanation.
+
+Evidence status:
+
+- available;
+- needs capture;
+- optional;
+- blocked;
+- confidential / cannot show.
+
+The evidence target list should use a table with:
+
+- Project;
+- Evidence target;
+- Evidence type;
+- Status;
+- Source path/link;
+- Confidentiality/risk note;
+- Portfolio use.
+
+## Visual Direction
+
+Samuel's "jump between design systems" idea is strategically useful if it
+communicates that he moves between:
+
+- GitHub: code, commits, architecture, proof of building;
+- Figma: flows, prototypes, interaction systems, visual/product design;
+- Notion/product knowledge systems: strategy, research, case-study narrative.
+
+This should be a portfolio interaction model, not decorative cosplay. The site
+should feel like one coherent portfolio that can reveal different kinds of proof,
+not a gimmick that imitates other products.
+
+## GitHub Issue Activation Order
+
+Only issue #10 should be active until this blueprint is approved.
+
+After approval, activate in this order:
+
+1. #11 Homepage + Selected Work Copy.
+2. #12 Meta Case Study Skeleton.
+3. #13 Rem Case Study Skeleton.
+4. #14 Wayfind Case Study Skeleton.
+5. #15 Visual Evidence Target List.
+6. #16 Read-Only Figma Evidence Pass.
+7. #17 Read-Only App Build Screenshot Pass.
+
+Keep #2 and #3 parked until the selected-work content model exists. Do not
+reopen or relabel closed infrastructure/activity issues unless the approved
+portfolio direction explicitly needs them.
+
+## Immediate Next Steps
+
+1. Samuel/Descartes reviews and approves or edits this blueprint.
+2. Activate #11 as the first copy task.
+3. Activate case-study skeleton issues after copy direction is clear.
+4. Build the evidence target list before any screenshot capture.
+5. Inspect Figma and app builds only against approved evidence targets.
+
+## Non-Goals For v1
+
+- Full activity feed.
+- Sprint/roadmap visualization.
+- GitHub issue state UI.
+- Notion sync reactivation.
+- Broad Rem or Wayfind product improvement.
+- Meta artifact recovery as a blocker.
+- Public publishing without explicit approval.


### PR DESCRIPTION
Closes #10

## Summary
- Adds `docs/portfolio-blueprint.md` as the approved jobs-first portfolio source of truth.
- Captures audience priority, positioning, homepage model, selected-work model, shared case-study architecture, and project-specific guidance for Meta, Rem, and Wayfind.
- Includes the Case Study Quality Rubric that downstream case-study issues must use.

## Validation
- `git diff --check` ✅

## Notes
- Docs-only PR; no UI changes, Notion sync changes, external mutations, app builds, or public publishing.
- Visual QA is not required because this does not alter rendered UI.