### PR TITLE
Rem case study: truthful Work copy + sharper Where it stands

### DIFF
--- a/projects/rem/index.html
+++ b/projects/rem/index.html
@@ -49,7 +49,7 @@
 
         <article class="np-flow"><div class="np-flow-media">Capture portrait media</div><div class="np-flow-copy"><p class="np-count">01 · Capture</p><h3>Get intent in before it disappears</h3><p>Someone can talk or type in their own words. Rem clarifies what they mean and turns it into a task, an event, or an action for a connected tool.</p></div></article>
         <article class="np-flow"><div class="np-flow-media">Agenda portrait media</div><div class="np-flow-copy"><p class="np-count">02 · Orient</p><h3>See tasks and time in one agenda</h3><p>Calendar commitments provide the timed context. Tasks hold the work. The agenda brings both together in a plan that can change with the day.</p></div></article>
-        <article class="np-flow"><div class="np-flow-media">Approved-action portrait media</div><div class="np-flow-copy"><p class="np-count">03 · Work</p><h3>Approve the next step before it runs</h3><p>Rem proposes an action, waits for confirmation, runs it through a gateway or connector, and reports the result back in the task’s log.</p></div></article>
+        <article class="np-flow"><div class="np-flow-media">Approved-action portrait media</div><div class="np-flow-copy"><p class="np-count">03 · Work</p><h3>Run a step, and follow exactly what it did</h3><p>Rem runs an action through a gateway and connectors you control, then reports the result in the task’s log. You own the gateway and granted the permissions, so the work stays legible and nothing happens off-screen.</p></div></article>
         <article class="np-flow"><div class="np-flow-media">Daily Brief portrait media</div><div class="np-flow-copy"><p class="np-count">04 · Brief</p><h3>Roll useful updates into one brief</h3><p>A daily brief gathers the work worth noticing into one update. When nothing needs attention, Rem can stay quiet.</p></div></article>
         <article class="np-wide"><div class="np-flow-media">Onboarding media</div><div class="np-flow-copy"><p class="np-count">05 · Onboarding</p><h3>Set expectations before Rem starts acting</h3><p>Onboarding introduces the assistant, the approval model, and connected tools before someone asks Rem to do work.</p></div></article>
       </section>
@@ -114,7 +114,7 @@
       <section class="np-section">
         <p class="np-label">Where it stands</p>
         <h2>Shipped on iPhone, then opened at the core</h2>
-        <p class="np-copy">Rem is live on the App Store for iPhone and has been released as an Apache-2.0 open-source project. The product is still being simplified and made more reliable as the open-core model takes shape.</p>
+        <p class="np-copy">Rem is live on the App Store for iPhone, and I released it as Apache-2.0 open source. Shipping forced the simplification the concept had been avoiding: the product got smaller and clearer as real use showed what didn’t earn its place. Opening it moved the work from adding features to making the core reliable, and the edge from the code to the product experience.</p>
       </section>
 
       <section class="np-section">


### PR DESCRIPTION
Fixes two copy blocks in the Rem case study (`projects/rem/index.html`) served at dev.samuelalake.com/projects/rem. Copy-only change; no structural, layout, or asset edits.

The old Work copy claimed a per-action approval gate ("proposes an action, waits for confirmation") that the product does not actually have — Rem auto-runs allowlisted actions. The new copy reframes control as **ownership + visibility** (you own the gateway, you granted the permissions, nothing happens off-screen), which is truthful. Where-it-stands is sharpened around the shipping / open-source outcome.

## Work block

**Before**
- Heading: `Approve the next step before it runs`
- Body: `Rem proposes an action, waits for confirmation, runs it through a gateway or connector, and reports the result back in the task's log.`

**After**
- Heading: `Run a step, and follow exactly what it did`
- Body: `Rem runs an action through a gateway and connectors you control, then reports the result in the task's log. You own the gateway and granted the permissions, so the work stays legible and nothing happens off-screen.`

## Where it stands block

**Before**
- Heading: `Shipped on iPhone, then opened at the core`
- Body: `Rem is live on the App Store for iPhone and has been released as an Apache-2.0 open-source project. The product is still being simplified and made more reliable as the open-core model takes shape.`

**After**
- Heading: `Shipped on iPhone, then opened at the core` (unchanged)
- Body: `Rem is live on the App Store for iPhone, and I released it as Apache-2.0 open source. Shipping forced the simplification the concept had been avoiding: the product got smaller and clearer as real use showed what didn't earn its place. Opening it moved the work from adding features to making the core reliable, and the edge from the code to the product experience.`

## Base branch note

Base is `claude/portfolio-redesign-58d67a`, **not** `main`. The redesigned narrative case study (`projects/rem/index.html` as plain HTML with these `np-*` sections) exists only on the redesign branch, which is what's currently deployed to dev.samuelalake.com. `main` still carries a different, older Rem page (a compiled React repo-preview artifact) that does not contain these strings, so a PR against `main` would not represent this change. Retarget to `main` once the redesign lands there.

No em dashes introduced. Only the two blocks above changed (`1 file changed, 2 insertions(+), 2 deletions(-)`).
